### PR TITLE
Fix OLM installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Other way to do this is to use Docker image in the repo root folder
 
 ```
 $ docker build -t operatorhub .
-docker run operatorhub
+docker run -ti -p 8080:8080 operatorhub
 ```
 
 ### Contributing

--- a/frontend/src/pages/documentation/HowToInstallOperators.tsx
+++ b/frontend/src/pages/documentation/HowToInstallOperators.tsx
@@ -6,7 +6,7 @@ import { ExternalLink } from '../../components/ExternalLink';
 import DocumentationPage from '../../components/page/DocumentationPage';
 import { olm, olmArchitecture, manageOperatorWithOlm, operatorGroupDesign } from '../../utils/documentationLinks';
 
-export interface HowToInstallOperatorsPageProps{
+export interface HowToInstallOperatorsPageProps {
   history: History
 }
 
@@ -45,6 +45,9 @@ const HowToInstallOperators: React.FC<HowToInstallOperatorsPageProps> = ({ histo
           </p>
           <p className="oh-documentation-page__code_snippet">
             <code>
+              kubectl create -f
+              https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/crds.yaml
+              <br />
               kubectl create -f
               https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml
             </code>


### PR DESCRIPTION
Following step in the below instruction
![image](https://user-images.githubusercontent.com/9593424/146168008-b860ebb7-694d-40b6-b4df-7be1fabec5e7.png)


leads to the below error

```
namespace/olm created
namespace/operators created
serviceaccount/olm-operator-serviceaccount created
clusterrole.rbac.authorization.k8s.io/system:controller:operator-lifecycle-manager created
clusterrolebinding.rbac.authorization.k8s.io/olm-operator-binding-olm created
deployment.apps/olm-operator created
deployment.apps/catalog-operator created
clusterrole.rbac.authorization.k8s.io/aggregate-olm-edit created
clusterrole.rbac.authorization.k8s.io/aggregate-olm-view created
unable to recognize "https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml": no matches for kind "OperatorGroup" in version "operators.coreos.com/v1"
unable to recognize "https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml": no matches for kind "OperatorGroup" in version "operators.coreos.com/v1"
unable to recognize "https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml": no matches for kind "ClusterServiceVersion" in version "operators.coreos.com/v1alpha1"
unable to recognize "https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/upstream/quickstart/olm.yaml": no matches for kind "CatalogSource" in version "operators.coreos.com/v1alpha1"
```
Definitions of CRDs are missing in a cluster, they have to be created previously as advised in docs of OLM https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md#manual-installation
thus I'm updating docs to include this step too.

---
Furthermore, the thing to consider is that for every operator in its installation guide step for installing OLM is included too e.g.

![image](https://user-images.githubusercontent.com/9593424/146167699-1193636c-ba9d-4330-8391-d9b264d5a896.png)
 
It explicitly specifies a specific version (the newest one) of it and uses a bash script to execute kubectl commands. Maybe everywhere this method should be recommended even in docs fixed in this PR.
