### PR TITLE
Fix failure in prod deployment

### DIFF
--- a/k8s/prod/kustomization.yaml
+++ b/k8s/prod/kustomization.yaml
@@ -9,8 +9,6 @@ patchesStrategicMerge:
   - patch-deploy-replicas.yaml
 resources:
   - route.yaml
-patchesStrategicMerge:
-  - patch-deploy-replicas.yaml
 images:
   - name: site
     newName: quay.io/operator-framework/operatorhubio


### PR DESCRIPTION
Signed-off-by: Maurizio Porrato <mporrato@redhat.com>

kustomization.yaml contains a duplicate field that trips the yaml validation.