### PR TITLE
Update operatorsFramework base url

### DIFF
--- a/frontend/src/utils/documentationLinks.ts
+++ b/frontend/src/utils/documentationLinks.ts
@@ -1,4 +1,4 @@
-export const operatorsFramework = 'https://github.com/k8s-operatorhub';
+export const operatorsFramework = 'https://github.com/operator-framework';
 export const operatorsRepo = `${operatorsFramework}/community-operators`;
 export const operatorsDocumentation = `https://k8s-operatorhub.github.io/community-operators`
 export const contributions = `${operatorsRepo}/tree/main/operators`;


### PR DESCRIPTION
Fixes #11 by updating the operator framework base url with the  Operator Framework github organization

Note: I wasn't able to follow build process due to missing `python` executable on my machine (Debian 12 has only `python3` available; I had same error with the provided Dockerfile).

I think this should be ok, because the change is just a constant value update.