### PR TITLE
Fix broken documentation links

### DIFF
--- a/frontend/src/components/page/Footer.tsx
+++ b/frontend/src/components/page/Footer.tsx
@@ -76,19 +76,19 @@ const Footer: React.FC<FooterProps> = ({ history, visible, ...props }) => (
               <h4 className="oh-footer__contents-right__links__list__header">NETWORK</h4>
               <ExternalLink
                 className="oh-footer__contents-right__links__list__link"
-                href={documentationLinks.hubTwitter}
-                text="Twitter"
+                href={documentationLinks.socialHubX}
+                text="X (Twitter)"
                 
               />
               <ExternalLink
                 className="oh-footer__contents-right__links__list__link"
-                href={documentationLinks.hubYoutube}
+                href={documentationLinks.socialHubYoutube}
                 text="YouTube"
                 
               />
               <ExternalLink
                 className="oh-footer__contents-right__links__list__link"
-                href={documentationLinks.operatorsFramework}
+                href={documentationLinks.operatorsFrameworkRepo}
                 text="GitHub"
                 
               />
@@ -100,7 +100,7 @@ const Footer: React.FC<FooterProps> = ({ history, visible, ...props }) => (
               />
               <ExternalLink
                 className="oh-footer__contents-right__links__list__link"
-                href={documentationLinks.kubernetesSlack}
+                href={documentationLinks.socialKubernetesSlack}
                 text="Join us on Slack"
                 
               />

--- a/frontend/src/pages/documentation/GettingStarted.tsx
+++ b/frontend/src/pages/documentation/GettingStarted.tsx
@@ -5,7 +5,7 @@ import { ExternalLink } from '../../components/ExternalLink';
 import DocumentationPage from '../../components/page/DocumentationPage';
 // @ts-ignore
 import maturityDetailsImg from '../../imgs/capability-level-diagram.svg';
-import { operatorSdk, gettingStarted, operatorsFramework } from '../../utils/documentationLinks';
+import { operatorSdk, gettingStarted, operatorsFrameworkRepo } from '../../utils/documentationLinks';
 import { InternalLink } from '../../components/InternalLink';
 import { History } from 'history';
 
@@ -116,7 +116,7 @@ const GettingStarted: React.FC<GettingStartedPageProps> = ({ history, ...props }
           </p>
           <p>
             Fortunately there is the <ExternalLink href={operatorSdk} text="operator-sdk" />, part of
-            the <ExternalLink href={operatorsFramework} text="Operator Framework" />, a community project that
+            the <ExternalLink href={operatorsFrameworkRepo} text="Operator Framework" />, a community project that
             aims at simplifying the whole process of Operator creation to just writing the custom operational logic
             inside the control loop.
           </p>

--- a/frontend/src/utils/documentationLinks.ts
+++ b/frontend/src/utils/documentationLinks.ts
@@ -1,37 +1,42 @@
-export const operatorsFramework = 'https://github.com/k8s-operatorhub';
-export const operatorsRepo = `${operatorsFramework}/community-operators`;
+export const gettingStarted = `https://operatorframework.io`;
+export const sdkQuickstartBundle = `https://sdk.operatorframework.io/docs/olm-integration/quickstart-bundle/`;
+export const manageOperatorWithOlm = `https://olm.operatorframework.io`;
+export const introBlog = `https://www.redhat.com/en/blog/introducing-operators-putting-operational-knowledge-into-software`;
+export const privacyPolicy = `https://www.redhat.com/en/about/privacy-policy`;
+export const semanticVersioning = `https://semver.org/`;
+export const socialHubX = `https://x.com/operatorhubio`;
+export const socialHubYoutube = 'https://www.youtube.com/watch?v=yzPvPJLxCl8&list=PLaR6Rq6Z4Iqcuu758T4YX6KRa1158v3Rb';
+export const socialKubernetesSlack = `https://kubernetes.slack.com/messages/kubernetes-operators`;
+
 export const operatorsDocumentation = `https://k8s-operatorhub.github.io/community-operators`
-export const contributions = `${operatorsRepo}/tree/main/operators`;
+export const operatorsRepo = `https://github.com/k8s-operatorhub/community-operators`;
+export const operatorsFrameworkRepo = 'https://github.com/operator-framework';
+
 export const operatorsRepoBeforePR = `${operatorsDocumentation}/contributing-prerequisites`;
 export const operatorsRepoRequirements = `${operatorsDocumentation}/packaging-operator`;
-export const operatorSdk = `${operatorsFramework}/operator-sdk`;
-export const sdkQuickstartBundle = `https://sdk.operatorframework.io/docs/olm-integration/quickstart-bundle/`;
-export const operatorCourier = `${operatorsFramework}/operator-courier`;
-export const operatorScorecard = `${operatorSdk}/blob/master/doc/test-framework/scorecard.md`;
-export const operatorBundle = `${operatorsRepo}#adding-your-operator`;
-export const olm = `${operatorsFramework}/operator-lifecycle-manager`;
-export const gettingStarted = `https://operatorframework.io`;
-export const operatorRegistry = `${operatorsFramework}/operator-registry`;
-export const bundleAnnotations = `${operatorsFramework}/operator-registry/blob/master/docs/design/operator-bundle.md#bundle-annotations`;
-export const bundleDockerfile = `${operatorsFramework}/operator-registry/blob/master/docs/design/operator-bundle.md#bundle-dockerfile`;
+export const operatorBundle = `${operatorsDocumentation}#add-your-operator`;
 export const manualTestingOnKubernetes = `${operatorsDocumentation}/operator-test-suite`;
 export const operatorMetadataValidation = `${operatorsDocumentation}/testing-operators`;
-export const prometheusOperator = `${contributions}/prometheus`;
-export const prometheusOperatorVersion = `${contributions}/prometheus/0.22.2`;
-export const olmArchitecture = `${olm}/blob/master/doc/design/architecture.md`;
 export const buildYourCSV = `${operatorsDocumentation}/packaging-operator`;
 export const createPackageManifest = `${operatorsDocumentation}/packaging-operator`;
-export const semanticVersioning = `https://semver.org/`;
-export const createBundle = `${operatorsRepo}/blob/master/docs/contributing.md#create-a-release-using-the-bundle-format`;
-export const packagemanifestToBundle = `${operatorsDocumentation}/packaging-operator`;
-export const discoveryCatalogs = `${olm}#discovery-catalogs-and-automated-upgrades`;
-export const introBlog = `https://web.archive.org/web/20170129131616/https://coreos.com/blog/introducing-operators.html`;
-export const sampleCode = `${operatorsFramework}/operator-sdk/blob/master/testdata/go/v3/memcached-operator/controllers/memcached_controller.go#L51-L137`;
-export const capabilityLevelModelDiagram = `${operatorSdk}/blob/master/doc/images/operator-capability-level.png`;
-export const manageOperatorWithOlm = `https://olm.operatorframework.io`;
-export const operatorGroupDesign = `${olm}/blob/master/doc/design/architecture.md#operator-group-design`;
-export const privacyPolicy = `https://www.redhat.com/en/about/privacy-policy`;
-export const kubernetesSlack = `https://kubernetes.slack.com/messages/kubernetes-operators`;
-export const hubTwitter = `https://twitter.com/operatorhubio`;
-export const hubYoutube = 'https://www.youtube.com/watch?v=yzPvPJLxCl8&list=PLaR6Rq6Z4Iqcuu758T4YX6KRa1158v3Rb';
+export const createBundle = `${operatorsDocumentation}/packaging-operator/#package-your-operator`;
+export const packagemanifestToBundle = `${operatorsDocumentation}/packaging-operator/#moving-from-packagemanifest-to-bundle-format`;
+
+export const contributions = `${operatorsRepo}/tree/main/operators`;
 export const fileAnIssue = `${operatorsRepo}/issues`;
+
+export const operatorCourier = `${operatorsFrameworkRepo}/operator-courier`;
+
+export const operatorRegistry = `${operatorsFrameworkRepo}/operator-registry`;
+export const bundleAnnotations = `${operatorRegistry}/blob/master/docs/design/operator-bundle.md#bundle-annotations`;
+export const bundleDockerfile = `${operatorRegistry}/blob/master/docs/design/operator-bundle.md#bundle-dockerfile`;
+
+export const operatorSdk = `${operatorsFrameworkRepo}/operator-sdk`;
+export const operatorScorecard = `${operatorSdk}/blob/master/doc/test-framework/scorecard.md`;
+export const capabilityLevelModelDiagram = `${operatorSdk}/blob/master/doc/images/operator-capability-level.png`;
+export const sampleCode = `${operatorSdk}/tree/master/testdata/go/v4/memcached-operator/internal/controller/memcached_controller.go#L81-L283`;
+
+export const olm = `${operatorsFrameworkRepo}/operator-lifecycle-manager`;
+export const olmArchitecture = `${olm}/blob/master/doc/design/architecture.md`;
+export const operatorGroupDesign = `${olm}/blob/master/doc/design/architecture.md#operator-group-design`;
+export const discoveryCatalogs = `${olm}#discovery-catalogs-and-automated-upgrades`;


### PR DESCRIPTION
Fixes https://github.com/k8s-operatorhub/operatorhub.io/issues/58
Fixes https://github.com/k8s-operatorhub/operatorhub.io/issues/11
Closes https://github.com/k8s-operatorhub/operatorhub.io/pull/49

I hope all links are correct now. Some of the links were 404, others linked to archived repositories.