### PR TITLE
fix: consider apiVersion when getting example yaml for crds

### DIFF
--- a/frontend/src/components/CustomResourceDefinitionsView.tsx
+++ b/frontend/src/components/CustomResourceDefinitionsView.tsx
@@ -28,7 +28,7 @@ const CustomResourceDefinitionsView: React.FC<CustomResourceDefinitionsViewProps
       <div className="oh-crd-tile-view">
         {customResourceDefinitions.map(crd => (
           <div className="oh-crd-tile" key={crd.name}>
-            <div className="oh-crd-tile__title">{crd.displayName}</div>
+            <div className="oh-crd-tile__title">{crd.displayName} ({crd.version})</div>
             <div className="oh-crd-tile__rule" />
             <div className="oh-crd-tile__description">{crd.description}</div>
             {showExamples && (

--- a/frontend/src/components/editor/BundleDownloader.js
+++ b/frontend/src/components/editor/BundleDownloader.js
@@ -259,7 +259,4 @@ const mapStateToProps = state => ({
   operatorPackage: state.editorState.operatorPackage
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(OperatorBundleDownloader);
+export default connect(mapStateToProps, mapDispatchToProps)(OperatorBundleDownloader);

--- a/frontend/src/components/editor/RulesEditor.js
+++ b/frontend/src/components/editor/RulesEditor.js
@@ -83,10 +83,18 @@ class RulesEditor extends React.Component {
     if (selections.includes('*') && selections.length > 1) {
       const prevSelections = _.get(rule, field);
       if (prevSelections.includes('*')) {
-        this.updateRule(rule, field, _.filter(selections, selection => selection !== '*'));
+        this.updateRule(
+          rule,
+          field,
+          _.filter(selections, selection => selection !== '*')
+        );
         return;
       }
-      this.updateRule(rule, field, _.filter(selections, selection => selection === '*'));
+      this.updateRule(
+        rule,
+        field,
+        _.filter(selections, selection => selection === '*')
+      );
       return;
     }
 

--- a/frontend/src/pages/operatorHub/OperatorHub.js
+++ b/frontend/src/pages/operatorHub/OperatorHub.js
@@ -612,7 +612,7 @@ class OperatorHub extends React.Component {
         {_.map(this.sortCategories(categories), category => (
           <div key={category} className={`oh-category-item ${category === selectedCategory ? 'selected' : ''}`}>
             <button className="oh-category-item__select" onClick={e => this.categorySelect(e, category)}>
-              {category.length == 0 ? 'All' : category}
+              {category.length === 0 ? 'All' : category}
             </button>
             {category === selectedCategory && (
               <button className="oh-category-item__deselect" onClick={e => this.categorySelect(e, '')}>
@@ -890,7 +890,4 @@ const mapStateToProps = state => ({
   ...state.viewState
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(OperatorHub);
+export default connect(mapStateToProps, mapDispatchToProps)(OperatorHub);

--- a/frontend/src/utils/operatorTypes.ts
+++ b/frontend/src/utils/operatorTypes.ts
@@ -198,6 +198,7 @@ export type NormalizedOperatorChannel = {
 export type NormalizedCrdPreview = {
     name: string
     kind: string
+    version: string
     displayName: string
     description: string
     yamlExample: object | null


### PR DESCRIPTION
Fixes #56 

## Description

- Added additional condition for checking apiVersion when searching for alm-examples for CRDs.
- Displayed a version next to CRD name for clarity (maybe there is a better design?)
- Applied lint fixes.

## Motivations

See #56. Additionally, CRD that has no corresponding alm-example is showing an incorrect one if an example of the same kind (different version) is available. See https://github.com/cryostatio/cryostat-operator/issues/909

## How to test

Use the following CSV, which both specify a CRD with >= 2 versions.

- https://gist.github.com/fanny-jiang/4f1829eb3262d47ebd64050a59fd7ec4
- https://gist.github.com/tthvo/4af24fa7122178afefc2acea2eccfb40

Use the CSV with preview page to see the changes.
