### PR TITLE
Add cwd to PATH in deploy.sh script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,9 @@ if [[ ! "$ENVIRO" =~ ^(dev|preprod|prod)$ ]]; then
     exit
 fi
 
+PATH="$PATH:$(pwd)/bin"
 mkdir -p bin
+
 if ! /usr/local/bin/oc > /dev/null 2>&1 ; then
     echo openshift origin client not found, installing
     curl -#L -o openshift.tar.gz https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz


### PR DESCRIPTION
The downloaded binaries oc and kustomization can't be found when execting the scribe because of path is missing in PATH variable.