### PR TITLE
remove DPAL script

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -110,8 +110,6 @@
 
   <link href="/static/fonts/fontawesome-webfont.woff2" rel="preload" as="font" crossorigin="anonymous">
   <link href="/static/fonts/PatternFlyIcons-webfont.ttf" rel="preload" as="font" crossorigin="anonymous">
-
-  <script id="adobe_dtm" defer src="//www.redhat.com/dtm.js" type="text/javascript"></script>
 </head>
 
 <body>
@@ -126,11 +124,6 @@
     </p>
   </noscript>
   <div id="root"></div>
-  <script type="text/javascript">
-    if (("undefined" !== typeof _satellite) && ("function" === typeof _satellite.pageBottom)) {
-      _satellite.pageBottom();
-    }
-  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Removes Adobe DTM/DPAL analytics script (`adobe_dtm` / `dtm.js`) from `frontend/src/index.html`
- Removes the `_satellite.pageBottom()` footer call that depends on it

This stops Adobe Analytics tracking on OperatorHub.io per Red Hat guidance for disabling DTM/DPAL.

## Test plan
- [ ] PR `Build server and site images` (`review.yml`) succeeds
- [ ] Confirm no `adobe_dtm` / `_satellite` references remain in `frontend/src/index.html`


Made with [Cursor](https://cursor.com)